### PR TITLE
Load baseUrl from `config.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ manage their work.
 
 ![Simulation of some wandering lumberjacks](simulation.gif)
 
+## Config
+
+You can define some basic configuration settings by editing the `config.json`
+file:
+
+```json
+{
+  "baseUrl": "http://localhost:4567"
+}
+```
+
+### Config options
+
+|Key|Type|Description|Default|
+|-|-|-|-|
+|`baseUrl`|`String`|Base url for the target server|`http://localhost:4567`|
+
 # With thanks
 
 Many thanks to:

--- a/simulation/Client.pde
+++ b/simulation/Client.pde
@@ -91,10 +91,11 @@ class PostRequest {
   }
 }
 
-String baseUrl = "http://localhost:4567";
-
 class Client {
+  String baseUrl;
+
   Client() {
+    baseUrl = config.baseUrl();
   }
 
   GetRequest get(String route) {

--- a/simulation/Config.pde
+++ b/simulation/Config.pde
@@ -1,0 +1,25 @@
+class Config {
+  private JSONObject jsonConfig, jsonDefault;
+
+  Config() {
+    File targetFile = new File(sketchPath("config.json"));
+    if (targetFile.exists()) {
+      jsonConfig = loadJSONObject("config.json");
+    }
+
+    jsonDefault = new JSONObject();
+    jsonDefault.setString("baseUrl", "http://localhost:4567");
+  }
+
+  String baseUrl() {
+    return getStringConfig("baseUrl");
+  }
+
+  private String getStringConfig(String keyName) {
+    if(jsonConfig != null && !jsonConfig.isNull(keyName)) {
+      return jsonConfig.getString(keyName);
+    }
+
+    return jsonDefault.getString(keyName);
+  }
+}

--- a/simulation/config.json
+++ b/simulation/config.json
@@ -1,0 +1,3 @@
+{
+  "baseUrl": "http://localhost:4567"
+}

--- a/simulation/simulation.pde
+++ b/simulation/simulation.pde
@@ -6,10 +6,12 @@ int logCount = 4;
 
 int zRotation, xRotation, zoom;
 ChallengeStack challengeStack;
+Config config;
 
 void setup() {
   size(1200, 800, P3D);
   frameRate(60);
+  config = new Config();
 
   challengeStack = new ChallengeStack();
 


### PR DESCRIPTION
Rather than requiring users to conform to the requirements of the application, it would be nice if they can set their own values for certain configuration options. The first option introduced is the `baseUrl` that the client uses to build requests.